### PR TITLE
Replace prints for logs and logs only send if is type error

### DIFF
--- a/src/embedded/app/SendToGrafana.lua
+++ b/src/embedded/app/SendToGrafana.lua
@@ -67,9 +67,9 @@ function send_data_grafana(temperature,humidity,pressure,INICIALES)
 		http.post(M.url, {headers = headers}, data,
 			function(code_return, _)
 				if (code_return ~= 204) then
-					print("error enviando   " .. code_return)
+					log.warn("Fail to send data to grafana code returned : " .. code_return)
         else
-          print("funciona")
+          log.trace("Sending data to Grafana")
 				end
                     
 		end) -- * post function end
@@ -90,7 +90,7 @@ function send_heap_and_uptime_grafana()
 --
 --  http.post(M.url, {headers = headers}, response, function (code_return, _)
 --    if (code ~= 204) then
---      print(" " .. code_return)
+--      log.warn("Fail to send Heap and Uptime to Grafana code returned: " .. code_return)
 --    end -- if end
 --  end) -- post function end
 end -- callback end

--- a/src/embedded/app/alerts.lua
+++ b/src/embedded/app/alerts.lua
@@ -35,7 +35,7 @@ function alerts.send_alert_to_grafana(message)
 	http.post(url, {headers = headers}, alert_string,
 		function(code_return, data_return)
 			if (code_return ~= 204) then
-				print(" " .. code_return)
+				log.warn("Fail to send Alert to Grafana code return: " .. code_return)
 			end
 	end) -- * post function end
 end -- * send_data_grafana end

--- a/src/embedded/app/configurator.lua
+++ b/src/embedded/app/configurator.lua
@@ -41,7 +41,7 @@ end
 -------------------------------------------------------------------------------------
 
 function configurator:create_config_file()
-  print("[!] Failed to read JSON file, creating a new one")
+  log.error("Failed to read JSON file, creating a new one")
   new_file = io.open("config.json", "w")
   new_file:write(
     '{"rotation_duration":5000,"rotation_period":360000,"min_temperature":37.3,"max_temperature":37.8,"ssid":"incubator","passwd":"1234554321"}')

--- a/src/embedded/app/incubatorController.lua
+++ b/src/embedded/app/incubatorController.lua
@@ -70,7 +70,6 @@ function temp_control(temperature, min_temp, max_temp)
             incubator.heater(true)
         else
             log.error("temperature is not changing")
-            alerts.send_alert_to_grafana("temperature is not changing")
             log.trace("turn resistor off")
             incubator.heater(false)
         end
@@ -126,11 +125,11 @@ end
 --! @param pin                            number of pin to watch
 ------------------------------------------------------------------------------------
 
-function trigger(gpio, _)
-    rotation_activate = true
-    print("[#] rotation working")
-    gpio.trig(gpio, gpio.INTR_DISABLE)
-end
+-- function trigger(gpio, _)
+--     rotation_activate = true
+--     print("[#] rotation working")
+--     gpio.trig(gpio, gpio.INTR_DISABLE)
+-- end
 
 ------------------------------------------------------------------------------------
 -- ! @function rotate                     is responsible for starting the rotation

--- a/src/embedded/app/wifiinit.lua
+++ b/src/embedded/app/wifiinit.lua
@@ -112,8 +112,8 @@ end -- end function
 ------------------------------------------------------------------------------------
 
 function wifi_connect_event(ev, info)
-	print(string.format("conecction to AP %s established!", tostring(info.ssid)))
-	print("Waiting for IP address...")
+	log.trace(string.format("conecction to AP %s established!", tostring(info.ssid)))
+	log.trace("Waiting for IP address...")
 
 	if disconnect_ct ~= nil then
 		disconnect_ct = nil
@@ -137,9 +137,9 @@ function wifi_got_ip_event(ev, info)
 	ONLINE = 1
 	IPADD = info.ip
 	IPGW = info.gw
-	print("NodeMCU IP config:", info.ip, "netmask", info.netmask, "gw", info.gw)
-	print("Startup will resume momentarily, you have 3 seconds to abort.")
-	print("Waiting...")
+	log.trace("NodeMCU IP config:", info.ip, "netmask", info.netmask, "gw", info.gw)
+	log.trace("Startup will resume momentarily, you have 3 seconds to abort.")
+	log.trace("Waiting...")
 	print(time.get(), " hora vieja")
 	if (not time.ntpenabled()) then
 		time.initntp("pool.ntp.org")
@@ -168,8 +168,8 @@ function wifi_disconnect_event(ev, info)
 	end
 
 	local total_tries = 10
-	print("\nWiFi connection to AP(" .. info.ssid .. ") has failed!")
-	print("Disconnect reason: " .. info.reason)
+	log.trace("\nWiFi connection to AP(" .. info.ssid .. ") has failed!")
+	log.trace("Disconnect reason: " .. info.reason)
 
 	if disconnect_ct == nil then
 		disconnect_ct = 1
@@ -178,13 +178,13 @@ function wifi_disconnect_event(ev, info)
 	end -- if end
 
 	if disconnect_ct < total_tries then
-		print("Retrying connection...(attempt " .. (disconnect_ct + 1) .. " of " .. total_tries .. ")")
+		log.trace("Retrying connection...(attempt " .. (disconnect_ct + 1) .. " of " .. total_tries .. ")")
 		wifi.sta.connect()
 	else
 		wifi.sta.disconnect()
 
 		if W.old_ssid and W.old_passwd then
-			print("Attempting to connect with previous credentials")
+			log.trace("Attempting to connect with previous credentials")
 			W:set_new_ssid(W.old_ssid)
 			W:set_passwd(W.old_passwd)
 			station_cfg = {
@@ -197,7 +197,7 @@ function wifi_disconnect_event(ev, info)
 			W.old_passwd = nil
 		end -- if end 
 
-		print("Reattempting WiFi connection in 10 seconds...")
+		log.trace("Reattempting WiFi connection in 10 seconds...")
 		mytimer = tmr.create()
 		mytimer:register(10000, tmr.ALARM_SINGLE, configwifi)
 		mytimer:start()
@@ -248,7 +248,7 @@ function W:on_change(new_config_table)
 end -- function end
 
 configwifi()
-print("Connecting to WiFi access point...")
+log.trace("Connecting to WiFi access point...")
 
 
 return W

--- a/src/embedded/libs/log.lua
+++ b/src/embedded/libs/log.lua
@@ -59,13 +59,13 @@ function log.send_to_grafana(message)
         ["Authorization"] = "Basic " .. token_grafana
     }
 
---    http.post(url, {
---        headers = headers
---    }, alert_string, function(code_return, data_return)
---        if (code_return ~= 204) then
---            print("error de loggg " .. code_return)
---        end
---    end) -- * post function end
+   http.post(url, {
+       headers = headers
+   }, alert_string, function(code_return, data_return)
+       if (code_return ~= 204) then
+           print("error de loggg " .. code_return)
+       end
+   end) -- * post function end
 end -- * send_data_grafana end
 
 local levels = {}
@@ -121,7 +121,7 @@ for i, x in ipairs(modes) do
             log.usecolor and "\27[0m" or "", lineinfo, msg))
 
         -- Output to grafana
-        if log.grafana then
+        if log.grafana and nameupper == "ERROR" then
             log.send_to_grafana(string.format("[%-6s%s] %s: %s\n", nameupper, strtime, lineinfo, msg))
         end
 


### PR DESCRIPTION
# Cambios 
1. Ahora solo se envian los logs de tipo error a grafana
2. Utilizo la libreria("logs.lua") para depurar en vez de utilizar prints como antes

#### nota: 
necesito ayuda para identificar en donde mas seria viable meter logs para depurar, por ejemplo, en la funcion [M.set_max_temp](https://github.com/JereC4str0/fork_proyecto_incubadora/blob/339867325ec019215ff4f9fc3df78b1f0e15a73e/src/embedded/app/incubator.lua#L247) deberia avisar cuando no pudo reflejar los cambios por que la temperatura minima fue mayor a la maxima? de ser asi haria los cambios en todas las funciones de este tipo avisando cuando algo salga mal 