### PR TITLE
Fix Incubator name with MAC

### DIFF
--- a/src/embedded/app/configurator.lua
+++ b/src/embedded/app/configurator.lua
@@ -42,6 +42,7 @@ end
 
 function configurator:create_config_file()
 	log.trace("Creating a new config file")
+	local mac = wifi.sta.getmac()
 	local new_file = io.open("config.json", "w")
 			local config = {
 					rotation_duration = 5000,
@@ -53,7 +54,7 @@ function configurator:create_config_file()
 					tray_three_date = 0,
 					incubation_period = 0,
 					hash = "1234567890",
-					incubator_name = "incubator_1",
+					incubator_name = string.format("incubator %s",mac),
 					max_hum = 70,
 					min_hum = 60
 			}

--- a/src/embedded/app/configurator.lua
+++ b/src/embedded/app/configurator.lua
@@ -42,7 +42,6 @@ end
 
 function configurator:create_config_file()
 	log.trace("Creating a new config file")
-	local mac = wifi.sta.getmac()
 	local new_file = io.open("config.json", "w")
 			local config = {
 					rotation_duration = 5000,
@@ -54,7 +53,7 @@ function configurator:create_config_file()
 					tray_three_date = 0,
 					incubation_period = 0,
 					hash = "1234567890",
-					incubator_name = string.format("incubator %s",mac),
+					incubator_name = string.format("incubadora-%s",wifi.sta.getmac()),
 					max_hum = 70,
 					min_hum = 60
 			}

--- a/src/embedded/app/incubator.lua
+++ b/src/embedded/app/incubator.lua
@@ -13,6 +13,7 @@
 
 -----------------------------------------------------------------------------
 credentials = require('credentials')
+mac = wifi.sta.getmac()
 
 local M = {
 	name                   = ..., -- module name, upvalue from require('module-name')
@@ -42,7 +43,7 @@ local M = {
 	tray_three_date = 0,
 	incubation_period = 0,
 	hash = 1235,
-	incubator_name = "incubator_1",
+	incubator_name = string.format("incubator %s",mac),
 	rotate_up			   = true
 }
 

--- a/src/embedded/app/incubator.lua
+++ b/src/embedded/app/incubator.lua
@@ -13,7 +13,6 @@
 
 -----------------------------------------------------------------------------
 credentials = require('credentials')
-mac = wifi.sta.getmac()
 
 local M = {
 	name                   = ..., -- module name, upvalue from require('module-name')
@@ -43,7 +42,7 @@ local M = {
 	tray_three_date = 0,
 	incubation_period = 0,
 	hash = 1235,
-	incubator_name = string.format("incubator %s",mac),
+	incubator_name = string.format("incubadora-%s",wifi.sta.getmac()),
 	rotate_up			   = true
 }
 


### PR DESCRIPTION
## Cambios 
- Ahora el nombre de la incubadora por defecto es la MAC adress del ESP32
- Este cambio tambien se ve reflejado cuando se crea un nuevo archivo de configuracion 

[![imagen.png](https://i.postimg.cc/4d2y5Y8G/imagen.png)](https://postimg.cc/DJs7fwkp)