### PR TITLE
fix: flutter APK CI build for Flutter 3.x

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -25,10 +25,14 @@ jobs:
           flutter-version: '3.x'
           channel: 'stable'
       
+      - name: Generate Android platform
+        working-directory: src/mobile_app
+        run: flutter create . --platforms android
+
       - name: Get dependencies
         working-directory: src/mobile_app
         run: flutter pub get
-      
+
       - name: Build APK (Release)
         working-directory: src/mobile_app
         run: flutter build apk --release

--- a/src/mobile_app/pubspec.yaml
+++ b/src/mobile_app/pubspec.yaml
@@ -5,7 +5,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^2.12.0
+  sdk: '>=3.0.0 <4.0.0'
 
 
 dependencies:
@@ -16,12 +16,8 @@ dependencies:
   http: ^1.1.0
   font_awesome_flutter: ^10.5.0
   google_fonts: ^5.1.0
-  android_flutter_wifi: ^0.1.2
-  permission_handler: ^9.2.0
-  firebase_auth: ^3.3.3
-  firebase_core: ^1.10.6
-  webview_flutter: ^2.0.13
-  flutter_inappwebview: ^5.3.2
+  permission_handler: ^11.3.1
+  flutter_inappwebview: ^6.1.5
   android_intent_plus: ^4.0.0
   meta: ^1.15.0
   shared_preferences: ^2.5.0


### PR DESCRIPTION
## Summary

- Update Dart SDK constraint from `^2.12.0` to `>=3.0.0 <4.0.0` (la versión anterior excluía Dart 3.x, incompatible con Flutter 3.41.7)
- Remove unused dependencies: `firebase_auth`, `firebase_core`, `android_flutter_wifi`, `webview_flutter` (ninguna es importada en el código)
- Update `permission_handler` → `^11.3.1` y `flutter_inappwebview` → `^6.1.5` (compatibles con Flutter 3.x)
- Upgrade CI Java 11 → **Java 17** (requerido por Android Gradle Plugin 8.x que genera Flutter 3.19+)
- Add `flutter create . --platforms android` step in CI to generate the missing `android/` platform directory (no estaba commiteado en el repo)

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` after merge
- [ ] Verify APK is produced and uploaded as artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)