### PR TITLE
fix: dart3 compilation errors in mobile app

### DIFF
--- a/src/mobile_app/lib/views/graf_home.dart
+++ b/src/mobile_app/lib/views/graf_home.dart
@@ -48,7 +48,7 @@ class _GHomeState extends State<GHome> {
       ),
       body: InAppWebView(
         initialUrlRequest: URLRequest(
-          url: Uri.parse(ApiConstants.getGrafanaUrl(incubadoraId!)),
+          url: WebUri(ApiConstants.getGrafanaUrl(incubadoraId!)),
         ),
         onWebViewCreated: (controller) {
           webViewController = controller;

--- a/src/mobile_app/lib/views/ntfy_home.dart
+++ b/src/mobile_app/lib/views/ntfy_home.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/src/mobile_app/pubspec.yaml
+++ b/src/mobile_app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   web_socket_channel: ^2.1.0
   http: ^1.1.0
   font_awesome_flutter: ^10.5.0
-  google_fonts: ^5.1.0
+  google_fonts: ^6.2.1
   permission_handler: ^11.3.1
   flutter_inappwebview: ^6.1.5
   android_intent_plus: ^4.0.0


### PR DESCRIPTION
## Summary

Fixes three compilation errors that appeared after the Flutter 3.x migration (#208):

- Remove unused `url_launcher` import in `ntfy_home.dart` (package not in pubspec)
- Fix `flutter_inappwebview` v6 API breaking change: `Uri` → `WebUri` in `graf_home.dart`
- Upgrade `google_fonts` `5.x` → `^6.2.1` — v5 has a const evaluation bug with `FontWeight` keys in Dart 3

## Test plan

- [ ] CI build passes (trigger via `workflow_dispatch` after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)