### PR TITLE
fix: resolve google_fonts v6 Config name collision

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,6 +1,9 @@
 name: Build and Publish APK Release
 
 on:
+  push:
+    branches:
+      - fix/flutter-apk-ci-build
   release:
     types: [created]
   workflow_dispatch:

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,9 +1,6 @@
 name: Build and Publish APK Release
 
 on:
-  push:
-    branches:
-      - fix/flutter-apk-ci-build
   release:
     types: [created]
   workflow_dispatch:

--- a/src/mobile_app/lib/views/counter_home.dart
+++ b/src/mobile_app/lib/views/counter_home.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:incubapp_lite/views/home.dart';
 import 'package:incubapp_lite/views/wifi_home.dart';
 import 'package:incubapp_lite/views/initial_home.dart';

--- a/src/mobile_app/lib/views/home.dart
+++ b/src/mobile_app/lib/views/home.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:incubapp_lite/services/api_services.dart';
 import 'package:flutter/material.dart';
 import 'package:incubapp_lite/views/initial_home.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:incubapp_lite/views/wifi_home.dart';
 import 'package:incubapp_lite/views/counter_home.dart';
 import 'package:incubapp_lite/views/graf_home.dart';

--- a/src/mobile_app/lib/views/initial_home.dart
+++ b/src/mobile_app/lib/views/initial_home.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:incubapp_lite/models/actual_model.dart';
 import 'package:incubapp_lite/models/config_model.dart';
 import 'package:incubapp_lite/views/home.dart';

--- a/src/mobile_app/lib/views/wifi_home.dart
+++ b/src/mobile_app/lib/views/wifi_home.dart
@@ -3,7 +3,7 @@ import 'package:incubapp_lite/models/actual_model.dart';
 import 'package:incubapp_lite/models/config_model.dart';
 import 'package:incubapp_lite/services/api_services.dart';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:incubapp_lite/views/initial_home.dart';
 import 'package:incubapp_lite/views/home.dart';
 import 'package:incubapp_lite/views/counter_home.dart';


### PR DESCRIPTION
## Summary

`google_fonts` v6 exports a `Config` class that conflicts with the app's own `Config` model in `config_model.dart`.

Fix: add `hide Config` to the `google_fonts` import in the 4 views that import both packages:
- `lib/views/home.dart`
- `lib/views/initial_home.dart`
- `lib/views/wifi_home.dart`
- `lib/views/counter_home.dart`

## Validation

✅ Build verified passing on fork CI before this PR ([run #25809328965](https://github.com/Pablomonte/Incubadora-Monitoreo/actions/runs/25809328965))

🤖 Generated with [Claude Code](https://claude.com/claude-code)